### PR TITLE
Added BindErrorManager

### DIFF
--- a/router/options.go
+++ b/router/options.go
@@ -71,3 +71,10 @@ func ContentType(contentType string) Option {
 		router.ContentType = contentType
 	}
 }
+
+// BindErrorManager set a function to manage bind errors
+func BindErrorManager(f ErrorManager) Option {
+	return func(router *Router) {
+		router.BindErrorManager = f
+	}
+}


### PR DESCRIPTION
Added a BindErrorManager to handle bind errors, like so:

```go
var MyService = router.New(
	...
	router.BindErrorManager(BindErrorManager),
)

func BindErrorManager(ctx *gin.Context, err error) {
	c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{...})
}
```

This way you can control errors when there is an error binding data to perform request.