### PR TITLE
Unexported fields

### DIFF
--- a/examples/api.go
+++ b/examples/api.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"fmt"
-	"mime/multipart"
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/long2ice/swagin/security"
+	"mime/multipart"
+	"net/http"
 )
 
 type TestQueryReq struct {

--- a/examples/api.go
+++ b/examples/api.go
@@ -2,16 +2,18 @@ package main
 
 import (
 	"fmt"
-	"github.com/gin-gonic/gin"
-	"github.com/long2ice/swagin/security"
 	"mime/multipart"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/long2ice/swagin/security"
 )
 
 type TestQueryReq struct {
-	Name     string `query:"name" validate:"required" json:"name" description:"name of model" default:"test"`
-	Token    string `header:"token" validate:"required" json:"token" default:"test"`
-	Optional string `query:"optional" json:"optional"`
+	unexported string
+	Name       string `query:"name" validate:"required" json:"name" description:"name of model" default:"test"`
+	Token      string `header:"token" validate:"required" json:"token" default:"test"`
+	Optional   string `query:"optional" json:"optional"`
 }
 
 func TestQuery(c *gin.Context, req TestQueryReq) {


### PR DESCRIPTION
Swagin crashes when there are unexported fields in the request struct, as in `TestQueryReq`. This PR fixes this bug so that unexported fields are simply ignored.