### PR TITLE
Manage maps in request struct

### DIFF
--- a/examples/api.go
+++ b/examples/api.go
@@ -43,9 +43,10 @@ func TestQueryPath(c *gin.Context, req TestQueryPathReq) {
 }
 
 type TestFormReq struct {
-	ID   int    `query:"id" validate:"required" json:"id" description:"id of model" default:"1"`
-	Name string `form:"name" validate:"required" json:"name" description:"name of model" default:"test"`
-	List []int  `form:"list" validate:"required" json:"list" description:"list of model"`
+	ID   int               `query:"id" validate:"required" json:"id" description:"id of model" default:"1"`
+	Name string            `form:"name" validate:"required" json:"name" description:"name of model" default:"test"`
+	List []int             `form:"list" validate:"required" json:"list" description:"list of model"`
+	Map  map[string]string `form:"map" validate:"required" json:"map" description:"a map"`
 }
 
 func TestForm(c *gin.Context, req TestFormReq) {

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -154,6 +154,9 @@ func (swagger *Swagger) getRequestSchemaByModel(model interface{}) *openapi3.Sch
 	} else if type_.Kind() == reflect.Slice {
 		schema = openapi3.NewArraySchema()
 		schema.Items = &openapi3.SchemaRef{Value: swagger.getRequestSchemaByModel(reflect.New(type_.Elem()).Elem().Interface())}
+	} else if type_.Kind() == reflect.Map {
+		schema = openapi3.NewObjectSchema()
+		schema.Items = &openapi3.SchemaRef{Value: swagger.getRequestSchemaByModel(reflect.New(type_.Elem()).Elem().Interface())}
 	} else {
 		schema = swagger.getSchemaByType(model, true)
 	}


### PR DESCRIPTION
Added maps management in request structs, as in TestFormReq of example code. Without this fix, Swagin crashes when a map is in the request struct.